### PR TITLE
Passing constant into parameter and applying standard naming convention

### DIFF
--- a/main.go
+++ b/main.go
@@ -42,7 +42,7 @@ func main() {
 	var acct *account.Account
 	var blockChain *ledger.Blockchain
 	var err error
-	var noder protocol.Noder
+	var noder protocol.UNode
 	log.Trace("Node version: ", config.Version)
 
 	if len(config.Parameters.BookKeepers) < account.DefaultBookKeeperCount {

--- a/net/httpjsonrpc/RPCserver.go
+++ b/net/httpjsonrpc/RPCserver.go
@@ -11,37 +11,62 @@ const (
 	LocalHost = "127.0.0.1"
 )
 
+const (
+	RPCGetBestBlockHash          = "getbestblockhash"
+	RPCGetBlock                  = "getblock" 
+	RPCGetBlockCount             = "getblockcount"
+	RPCGetBlockHash              = "getblockhash"
+	RPCGetConnectionCount        = "getconnectioncount"
+	RPCGetRawMemPool             = "getrawmempool"
+	RPCGetRawTransaction         = "getrawtransaction"
+	RPCSendRawTransaction        = "sendrawtransaction"
+	RPCGetVersion                = "getversion"
+	RPCGetNeighbor               = "getneighbor"
+	RPCGetNodeState              = "getnodestate"
+	RPCSetDebugInfo              = "setdebuginfo"
+	RPCSendToAddress             = "sendtoaddress"
+	RPCLockAsset                 = "lockasset"
+	RPCCreateMultisigTransaction = "createmultisigtransaction"
+	RPCSignMultisigTrasaction    = "signmultisigtransaction"
+
+	RPCRegisterUser = "registeruser"
+	RPCPostarticle  = "postarticle"
+	RPCReplyArticle = "replyarticle"
+	RPCLikeArticle  = "likearticle"
+	RPCWithdrawl    = "withdrawal"
+)
+
 func StartRPCServer() {
 	log.Debug()
 	http.HandleFunc("/", Handle)
 
-	HandleFunc("getbestblockhash", getBestBlockHash)
-	HandleFunc("getblock", getBlock)
-	HandleFunc("getblockcount", getBlockCount)
-	HandleFunc("getblockhash", getBlockHash)
-	HandleFunc("getconnectioncount", getConnectionCount)
-	HandleFunc("getrawmempool", getRawMemPool)
-	HandleFunc("getrawtransaction", getRawTransaction)
-	HandleFunc("sendrawtransaction", sendRawTransaction)
-	HandleFunc("getversion", getVersion)
-	HandleFunc("getneighbor", getNeighbor)
-	HandleFunc("getnodestate", getNodeState)
+	HandleFunc(RPCGetBestBlockHash, getBestBlockHash)
+	HandleFunc(RPCGetBlock, getBlock)
+	HandleFunc(RPCGetBlockCount, getBlockCount)
+	HandleFunc(RPCGetBlockHash, getBlockHash)
+	HandleFunc(RPCGetConnectionCount, getConnectionCount)
+	HandleFunc(RPCGetRawMemPool, getRawMemPool)
+	HandleFunc(RPCGetRawTransaction, getRawTransaction)
+	HandleFunc(RPCSendRawTransaction, sendRawTransaction)
+	HandleFunc(RPCGetVersion, getVersion)
+	HandleFunc(RPCGetNeighbor, getNeighbor)
+	HandleFunc(RPCGetNodeState, getNodeState)
 
-	HandleFunc("setdebuginfo", setDebugInfo)
-	HandleFunc("sendtoaddress", sendToAddress)
-	HandleFunc("lockasset", lockAsset)
+	HandleFunc(RPCSetDebugInfo, setDebugInfo)
+	HandleFunc(RPCSendToAddress, sendToAddress)
+	HandleFunc(RPCLockAsset, lockAsset)
 
-	HandleFunc("createmultisigtransaction", createMultisigTransaction)
-	HandleFunc("signmultisigtransaction", signMultisigTransaction)
+	HandleFunc(RPCCreateMultisigTransaction, createMultisigTransaction)
+	HandleFunc(RPCSignMultisigTrasaction, signMultisigTransaction)
 
 	// Following transactions should be passed through
 	// sendrawtrasaction interface of restfull interface.
 	// Put them here only for forum feature testing.
-	HandleFunc("registeruser", registerUser)
-	HandleFunc("postarticle", postArticle)
-	HandleFunc("replyarticle", replyArticle)
-	HandleFunc("likearticle", likeArticle)
-	HandleFunc("withdrawal", withdrawal)
+	HandleFunc(RPCRegisterUser, registerUser)
+	HandleFunc(RPCPostarticle, postArticle)
+	HandleFunc(RPCReplyArticle, replyArticle)
+	HandleFunc(RPCLikeArticle, likeArticle)
+	HandleFunc(RPCWithdrawl, withdrawal)
 
 	err := http.ListenAndServe(LocalHost+":"+strconv.Itoa(Parameters.HttpJsonPort), nil)
 	if err != nil {

--- a/net/httpjsonrpc/common.go
+++ b/net/httpjsonrpc/common.go
@@ -23,7 +23,7 @@ func init() {
 
 //an instance of the multiplexer
 var mainMux ServeMux
-var node Noder
+var node UNode
 var dBFT *dbft.DbftService
 
 //multiplexer that keeps track of every function to be called on specific rpc call
@@ -135,7 +135,7 @@ type ConsensusInfo struct {
 	// TODO
 }
 
-func RegistRpcNode(n Noder) {
+func RegistRpcNode(n UNode) {
 	if node == nil {
 		node = n
 	}

--- a/net/httpjsonrpc/interfaces.go
+++ b/net/httpjsonrpc/interfaces.go
@@ -122,7 +122,7 @@ func getCurrentDirectory() string {
 }
 func getBestBlockHash(params []interface{}) map[string]interface{} {
 	hash := ledger.DefaultLedger.Blockchain.CurrentBlockHash()
-	return UnetworkRpc(BytesToHexString(hash.ToArrayReverse()))
+	return UNetworkRPC(BytesToHexString(hash.ToArrayReverse()))
 }
 
 // Input JSON string examples for getblock method as following:
@@ -130,7 +130,7 @@ func getBestBlockHash(params []interface{}) map[string]interface{} {
 //   {"jsonrpc": "2.0", "method": "getblock", "params": ["aabbcc.."], "id": 0}
 func getBlock(params []interface{}) map[string]interface{} {
 	if len(params) < 1 {
-		return UnetworkRpcNil
+		return UNetworkRPCNil
 	}
 	var err error
 	var hash Uint256
@@ -140,25 +140,25 @@ func getBlock(params []interface{}) map[string]interface{} {
 		index := uint32(params[0].(float64))
 		hash, err = ledger.DefaultLedger.Store.GetBlockHash(index)
 		if err != nil {
-			return UnetworkRpcUnknownBlock
+			return UNetworkRPCUnknownBlock
 		}
 	// block hash
 	case string:
 		str := params[0].(string)
 		hex, err := HexStringToBytesReverse(str)
 		if err != nil {
-			return UnetworkRpcInvalidParameter
+			return UNetworkRPCInvalidParameter
 		}
 		if err := hash.Deserialize(bytes.NewReader(hex)); err != nil {
-			return UnetworkRpcInvalidTransaction
+			return UNetworkRPCInvalidTransaction
 		}
 	default:
-		return UnetworkRpcInvalidParameter
+		return UNetworkRPCInvalidParameter
 	}
 
 	block, err := ledger.DefaultLedger.Store.GetBlock(hash)
 	if err != nil {
-		return UnetworkRpcUnknownBlock
+		return UNetworkRPCUnknownBlock
 	}
 
 	blockHead := &BlockHead{
@@ -186,34 +186,34 @@ func getBlock(params []interface{}) map[string]interface{} {
 		BlockData:    blockHead,
 		Transactions: trans,
 	}
-	return UnetworkRpc(b)
+	return UNetworkRPC(b)
 }
 
 func getBlockCount(params []interface{}) map[string]interface{} {
-	return UnetworkRpc(ledger.DefaultLedger.Blockchain.BlockHeight + 1)
+	return UNetworkRPC(ledger.DefaultLedger.Blockchain.BlockHeight + 1)
 }
 
 // A JSON example for getblockhash method as following:
 //   {"jsonrpc": "2.0", "method": "getblockhash", "params": [1], "id": 0}
 func getBlockHash(params []interface{}) map[string]interface{} {
 	if len(params) < 1 {
-		return UnetworkRpcNil
+		return UNetworkRPCNil
 	}
 	switch params[0].(type) {
 	case float64:
 		height := uint32(params[0].(float64))
 		hash, err := ledger.DefaultLedger.Store.GetBlockHash(height)
 		if err != nil {
-			return UnetworkRpcUnknownBlock
+			return UNetworkRPCUnknownBlock
 		}
-		return UnetworkRpc(BytesToHexString(hash.ToArrayReverse()))
+		return UNetworkRPC(BytesToHexString(hash.ToArrayReverse()))
 	default:
-		return UnetworkRpcInvalidParameter
+		return UNetworkRPCInvalidParameter
 	}
 }
 
 func getConnectionCount(params []interface{}) map[string]interface{} {
-	return UnetworkRpc(node.GetConnectionCnt())
+	return UNetworkRPC(node.GetConnectionCnt())
 }
 
 func getRawMemPool(params []interface{}) map[string]interface{} {
@@ -223,37 +223,37 @@ func getRawMemPool(params []interface{}) map[string]interface{} {
 		txs = append(txs, TransArryByteToHexString(t))
 	}
 	if len(txs) == 0 {
-		return UnetworkRpcNil
+		return UNetworkRPCNil
 	}
-	return UnetworkRpc(txs)
+	return UNetworkRPC(txs)
 }
 
 // A JSON example for getrawtransaction method as following:
 //   {"jsonrpc": "2.0", "method": "getrawtransaction", "params": ["transactioin hash in hex"], "id": 0}
 func getRawTransaction(params []interface{}) map[string]interface{} {
 	if len(params) < 1 {
-		return UnetworkRpcNil
+		return UNetworkRPCNil
 	}
 	switch params[0].(type) {
 	case string:
 		str := params[0].(string)
 		hex, err := HexStringToBytesReverse(str)
 		if err != nil {
-			return UnetworkRpcInvalidParameter
+			return UNetworkRPCInvalidParameter
 		}
 		var hash Uint256
 		err = hash.Deserialize(bytes.NewReader(hex))
 		if err != nil {
-			return UnetworkRpcInvalidTransaction
+			return UNetworkRPCInvalidTransaction
 		}
 		tx, err := ledger.DefaultLedger.Store.GetTransaction(hash)
 		if err != nil {
-			return UnetworkRpcUnknownTransaction
+			return UNetworkRPCUnknownTransaction
 		}
 		tran := TransArryByteToHexString(tx)
-		return UnetworkRpc(tran)
+		return UNetworkRPC(tran)
 	default:
-		return UnetworkRpcInvalidParameter
+		return UNetworkRPCInvalidParameter
 	}
 }
 
@@ -261,7 +261,7 @@ func getRawTransaction(params []interface{}) map[string]interface{} {
 //   {"jsonrpc": "2.0", "method": "sendrawtransaction", "params": ["raw transactioin in hex"], "id": 0}
 func sendRawTransaction(params []interface{}) map[string]interface{} {
 	if len(params) < 1 {
-		return UnetworkRpcNil
+		return UNetworkRPCNil
 	}
 	var hash Uint256
 	switch params[0].(type) {
@@ -269,38 +269,38 @@ func sendRawTransaction(params []interface{}) map[string]interface{} {
 		str := params[0].(string)
 		hex, err := HexStringToBytes(str)
 		if err != nil {
-			return UnetworkRpcInvalidParameter
+			return UNetworkRPCInvalidParameter
 		}
 		var txn tx.Transaction
 		if err := txn.Deserialize(bytes.NewReader(hex)); err != nil {
-			return UnetworkRpcInvalidTransaction
+			return UNetworkRPCInvalidTransaction
 		}
 
 		//if txn.TxType != tx.InvokeCode && txn.TxType != tx.DeployCode &&
 		//	txn.TxType != tx.TransferAsset && txn.TxType != tx.LockAsset &&
 		//	txn.TxType != tx.BookKeeper {
-		//	return UnetworkRpc("invalid transaction type")
+		//	return UNetworkRPC("invalid transaction type")
 		//}
 		hash = txn.Hash()
 		if errCode := VerifyAndSendTx(&txn); errCode != ErrNoError {
-			return UnetworkRpc(errCode.Error())
+			return UNetworkRPC(errCode.Error())
 		}
 	default:
-		return UnetworkRpcInvalidParameter
+		return UNetworkRPCInvalidParameter
 	}
-	return UnetworkRpc(BytesToHexString(hash.ToArrayReverse()))
+	return UNetworkRPC(BytesToHexString(hash.ToArrayReverse()))
 }
 
 func getTxout(params []interface{}) map[string]interface{} {
 	//TODO
-	return UnetworkRpcUnsupported
+	return UNetworkRPCUnsupported
 }
 
 // A JSON example for submitblock method as following:
 //   {"jsonrpc": "2.0", "method": "submitblock", "params": ["raw block in hex"], "id": 0}
 func submitBlock(params []interface{}) map[string]interface{} {
 	if len(params) < 1 {
-		return UnetworkRpcNil
+		return UNetworkRPCNil
 	}
 	switch params[0].(type) {
 	case string:
@@ -308,26 +308,26 @@ func submitBlock(params []interface{}) map[string]interface{} {
 		hex, _ := HexStringToBytes(str)
 		var block ledger.Block
 		if err := block.Deserialize(bytes.NewReader(hex)); err != nil {
-			return UnetworkRpcInvalidBlock
+			return UNetworkRPCInvalidBlock
 		}
 		if err := ledger.DefaultLedger.Blockchain.AddBlock(&block); err != nil {
-			return UnetworkRpcInvalidBlock
+			return UNetworkRPCInvalidBlock
 		}
 		if err := node.LocalNode().CleanSubmittedTransactions(&block); err != nil {
-			return UnetworkRpcInternalError
+			return UNetworkRPCInternalError
 		}
 		if err := node.Xmit(&block); err != nil {
-			return UnetworkRpcInternalError
+			return UNetworkRPCInternalError
 		}
 	default:
-		return UnetworkRpcInvalidParameter
+		return UNetworkRPCInvalidParameter
 	}
-	return UnetworkRpcSuccess
+	return UNetworkRPCSuccess
 }
 
 func getNeighbor(params []interface{}) map[string]interface{} {
 	addr, _ := node.GetNeighborAddrs()
-	return UnetworkRpc(addr)
+	return UNetworkRPC(addr)
 }
 
 func getNodeState(params []interface{}) map[string]interface{} {
@@ -343,38 +343,38 @@ func getNodeState(params []interface{}) map[string]interface{} {
 		TxnCnt:   node.GetTxnCnt(),
 		RxTxnCnt: node.GetRxTxnCnt(),
 	}
-	return UnetworkRpc(n)
+	return UNetworkRPC(n)
 }
 
 func startConsensus(params []interface{}) map[string]interface{} {
 	if err := dBFT.Start(); err != nil {
-		return UnetworkRpcFailed
+		return UNetworkRPCFailed
 	}
-	return UnetworkRpcSuccess
+	return UNetworkRPCSuccess
 }
 
 func stopConsensus(params []interface{}) map[string]interface{} {
 	if err := dBFT.Halt(); err != nil {
-		return UnetworkRpcFailed
+		return UNetworkRPCFailed
 	}
-	return UnetworkRpcSuccess
+	return UNetworkRPCSuccess
 }
 
 func sendSampleTransaction(params []interface{}) map[string]interface{} {
 	if len(params) < 1 {
-		return UnetworkRpcNil
+		return UNetworkRPCNil
 	}
 	var txType string
 	switch params[0].(type) {
 	case string:
 		txType = params[0].(string)
 	default:
-		return UnetworkRpcInvalidParameter
+		return UNetworkRPCInvalidParameter
 	}
 
 	issuer, err := account.NewAccount()
 	if err != nil {
-		return UnetworkRpc("Failed to create account")
+		return UNetworkRPC("Failed to create account")
 	}
 	admin := issuer
 
@@ -394,35 +394,35 @@ func sendSampleTransaction(params []interface{}) map[string]interface{} {
 			SignTx(admin, regTx)
 			VerifyAndSendTx(regTx)
 		}
-		return UnetworkRpc(fmt.Sprintf("%d transaction(s) was sent", num))
+		return UNetworkRPC(fmt.Sprintf("%d transaction(s) was sent", num))
 	default:
-		return UnetworkRpc("Invalid transacion type")
+		return UNetworkRPC("Invalid transacion type")
 	}
 }
 
 func setDebugInfo(params []interface{}) map[string]interface{} {
 	if len(params) < 1 {
-		return UnetworkRpcInvalidParameter
+		return UNetworkRPCInvalidParameter
 	}
 	switch params[0].(type) {
 	case float64:
 		level := params[0].(float64)
 		if err := log.Log.SetDebugLevel(int(level)); err != nil {
-			return UnetworkRpcInvalidParameter
+			return UNetworkRPCInvalidParameter
 		}
 	default:
-		return UnetworkRpcInvalidParameter
+		return UNetworkRPCInvalidParameter
 	}
-	return UnetworkRpcSuccess
+	return UNetworkRPCSuccess
 }
 
 func getVersion(params []interface{}) map[string]interface{} {
-	return UnetworkRpc(config.Version)
+	return UNetworkRPC(config.Version)
 }
 
 func uploadDataFile(params []interface{}) map[string]interface{} {
 	if len(params) < 1 {
-		return UnetworkRpcNil
+		return UNetworkRPCNil
 	}
 
 	rbuf := make([]byte, 4)
@@ -433,27 +433,27 @@ func uploadDataFile(params []interface{}) map[string]interface{} {
 
 	data, err := base64.StdEncoding.DecodeString(str)
 	if err != nil {
-		return UnetworkRpcInvalidParameter
+		return UNetworkRPCInvalidParameter
 	}
 	f, err := os.OpenFile(tmpname, os.O_WRONLY|os.O_CREATE, 0664)
 	if err != nil {
-		return UnetworkRpcIOError
+		return UNetworkRPCIOError
 	}
 	defer f.Close()
 	f.Write(data)
 
 	refpath, err := AddFileIPFS(tmpname, true)
 	if err != nil {
-		return UnetworkRpcAPIError
+		return UNetworkRPCAPIError
 	}
 
-	return UnetworkRpc(refpath)
+	return UNetworkRPC(refpath)
 
 }
 
 func regDataFile(params []interface{}) map[string]interface{} {
 	if len(params) < 1 {
-		return UnetworkRpcNil
+		return UNetworkRPCNil
 	}
 	var hash Uint256
 	switch params[0].(type) {
@@ -461,71 +461,71 @@ func regDataFile(params []interface{}) map[string]interface{} {
 		str := params[0].(string)
 		hex, err := HexStringToBytes(str)
 		if err != nil {
-			return UnetworkRpcInvalidParameter
+			return UNetworkRPCInvalidParameter
 		}
 		var txn tx.Transaction
 		if err := txn.Deserialize(bytes.NewReader(hex)); err != nil {
-			return UnetworkRpcInvalidTransaction
+			return UNetworkRPCInvalidTransaction
 		}
 
 		hash = txn.Hash()
 		if errCode := VerifyAndSendTx(&txn); errCode != ErrNoError {
-			return UnetworkRpcInternalError
+			return UNetworkRPCInternalError
 		}
 	default:
-		return UnetworkRpcInvalidParameter
+		return UNetworkRPCInvalidParameter
 	}
-	return UnetworkRpc(BytesToHexString(hash.ToArrayReverse()))
+	return UNetworkRPC(BytesToHexString(hash.ToArrayReverse()))
 }
 
 func catDataRecord(params []interface{}) map[string]interface{} {
 	if len(params) < 1 {
-		return UnetworkRpcNil
+		return UNetworkRPCNil
 	}
 	switch params[0].(type) {
 	case string:
 		str := params[0].(string)
 		b, err := HexStringToBytesReverse(str)
 		if err != nil {
-			return UnetworkRpcInvalidParameter
+			return UNetworkRPCInvalidParameter
 		}
 		var hash Uint256
 		err = hash.Deserialize(bytes.NewReader(b))
 		if err != nil {
-			return UnetworkRpcInvalidTransaction
+			return UNetworkRPCInvalidTransaction
 		}
 		tx, err := ledger.DefaultLedger.Store.GetTransaction(hash)
 		if err != nil {
-			return UnetworkRpcUnknownTransaction
+			return UNetworkRPCUnknownTransaction
 		}
 		tran := TransArryByteToHexString(tx)
 		info := tran.Payload.(*DataFileInfo)
 		//ref := string(record.RecordData[:])
-		return UnetworkRpc(info)
+		return UNetworkRPC(info)
 	default:
-		return UnetworkRpcInvalidParameter
+		return UNetworkRPCInvalidParameter
 	}
 }
 
 func getDataFile(params []interface{}) map[string]interface{} {
 	if len(params) < 1 {
-		return UnetworkRpcNil
+		return UNetworkRPCNil
 	}
 	switch params[0].(type) {
 	case string:
 		str := params[0].(string)
 		hex, err := HexStringToBytesReverse(str)
 		if err != nil {
-			return UnetworkRpcInvalidParameter
+			return UNetworkRPCInvalidParameter
 		}
 		var hash Uint256
 		err = hash.Deserialize(bytes.NewReader(hex))
 		if err != nil {
-			return UnetworkRpcInvalidTransaction
+			return UNetworkRPCInvalidTransaction
 		}
 		tx, err := ledger.DefaultLedger.Store.GetTransaction(hash)
 		if err != nil {
-			return UnetworkRpcUnknownTransaction
+			return UNetworkRPCUnknownTransaction
 		}
 
 		tran := TransArryByteToHexString(tx)
@@ -533,12 +533,12 @@ func getDataFile(params []interface{}) map[string]interface{} {
 
 		err = GetFileIPFS(info.IPFSPath, info.Filename)
 		if err != nil {
-			return UnetworkRpcAPIError
+			return UNetworkRPCAPIError
 		}
 		//TODO: shoud return download address
-		return UnetworkRpcSuccess
+		return UNetworkRPCSuccess
 	default:
-		return UnetworkRpcInvalidParameter
+		return UNetworkRPCInvalidParameter
 	}
 }
 
@@ -551,159 +551,159 @@ func getWalletDir() string {
 
 func addAccount(params []interface{}) map[string]interface{} {
 	if Wallet == nil {
-		return UnetworkRpc("open wallet first")
+		return UNetworkRPC("open wallet first")
 	}
 	account, err := Wallet.CreateAccount()
 	if err != nil {
-		return UnetworkRpc("create account error:" + err.Error())
+		return UNetworkRPC("create account error:" + err.Error())
 	}
 
 	if err := Wallet.CreateContract(account); err != nil {
-		return UnetworkRpc("create contract error:" + err.Error())
+		return UNetworkRPC("create contract error:" + err.Error())
 	}
 
 	address, err := account.ProgramHash.ToAddress()
 	if err != nil {
-		return UnetworkRpc("generate address error:" + err.Error())
+		return UNetworkRPC("generate address error:" + err.Error())
 	}
 
-	return UnetworkRpc(address)
+	return UNetworkRPC(address)
 }
 
 func deleteAccount(params []interface{}) map[string]interface{} {
 	if len(params) < 1 {
-		return UnetworkRpcNil
+		return UNetworkRPCNil
 	}
 	var address string
 	switch params[0].(type) {
 	case string:
 		address = params[0].(string)
 	default:
-		return UnetworkRpcInvalidParameter
+		return UNetworkRPCInvalidParameter
 	}
 	if Wallet == nil {
-		return UnetworkRpc("open wallet first")
+		return UNetworkRPC("open wallet first")
 	}
 	programHash, err := ToScriptHash(address)
 	if err != nil {
-		return UnetworkRpc("invalid address:" + err.Error())
+		return UNetworkRPC("invalid address:" + err.Error())
 	}
 	if err := Wallet.DeleteAccount(programHash); err != nil {
-		return UnetworkRpc("Delete account error:" + err.Error())
+		return UNetworkRPC("Delete account error:" + err.Error())
 	}
 	if err := Wallet.DeleteContract(programHash); err != nil {
-		return UnetworkRpc("Delete contract error:" + err.Error())
+		return UNetworkRPC("Delete contract error:" + err.Error())
 	}
 	if err := Wallet.DeleteCoinsData(programHash); err != nil {
-		return UnetworkRpc("Delete coins error:" + err.Error())
+		return UNetworkRPC("Delete coins error:" + err.Error())
 	}
 
-	return UnetworkRpc(true)
+	return UNetworkRPC(true)
 }
 
 func makeRegTxn(params []interface{}) map[string]interface{} {
 	if len(params) < 2 {
-		return UnetworkRpcNil
+		return UNetworkRPCNil
 	}
 	var assetName, assetValue string
 	switch params[0].(type) {
 	case string:
 		assetName = params[0].(string)
 	default:
-		return UnetworkRpcInvalidParameter
+		return UNetworkRPCInvalidParameter
 	}
 	switch params[1].(type) {
 	case string:
 		assetValue = params[1].(string)
 	default:
-		return UnetworkRpcInvalidParameter
+		return UNetworkRPCInvalidParameter
 	}
 	if Wallet == nil {
-		return UnetworkRpc("open wallet first")
+		return UNetworkRPC("open wallet first")
 	}
 
 	regTxn, err := sdk.MakeRegTransaction(Wallet, assetName, assetValue)
 	if err != nil {
-		return UnetworkRpcInternalError
+		return UNetworkRPCInternalError
 	}
 
 	if errCode := VerifyAndSendTx(regTxn); errCode != ErrNoError {
-		return UnetworkRpcInvalidTransaction
+		return UNetworkRPCInvalidTransaction
 	}
-	return UnetworkRpc(true)
+	return UNetworkRPC(true)
 }
 
 func makeIssueTxn(params []interface{}) map[string]interface{} {
 	if len(params) < 3 {
-		return UnetworkRpcNil
+		return UNetworkRPCNil
 	}
 	var asset, value, address string
 	switch params[0].(type) {
 	case string:
 		asset = params[0].(string)
 	default:
-		return UnetworkRpcInvalidParameter
+		return UNetworkRPCInvalidParameter
 	}
 	switch params[1].(type) {
 	case string:
 		value = params[1].(string)
 	default:
-		return UnetworkRpcInvalidParameter
+		return UNetworkRPCInvalidParameter
 	}
 	switch params[2].(type) {
 	case string:
 		address = params[2].(string)
 	default:
-		return UnetworkRpcInvalidParameter
+		return UNetworkRPCInvalidParameter
 	}
 	if Wallet == nil {
-		return UnetworkRpc("open wallet first")
+		return UNetworkRPC("open wallet first")
 	}
 	tmp, err := HexStringToBytesReverse(asset)
 	if err != nil {
-		return UnetworkRpc("invalid asset ID")
+		return UNetworkRPC("invalid asset ID")
 	}
 	var assetID Uint256
 	if err := assetID.Deserialize(bytes.NewReader(tmp)); err != nil {
-		return UnetworkRpc("invalid asset hash")
+		return UNetworkRPC("invalid asset hash")
 	}
 	issueTxn, err := sdk.MakeIssueTransaction(Wallet, assetID, address, value)
 	if err != nil {
-		return UnetworkRpcInternalError
+		return UNetworkRPCInternalError
 	}
 
 	if errCode := VerifyAndSendTx(issueTxn); errCode != ErrNoError {
-		return UnetworkRpcInvalidTransaction
+		return UNetworkRPCInvalidTransaction
 	}
 
-	return UnetworkRpc(true)
+	return UNetworkRPC(true)
 }
 
 func sendToAddress(params []interface{}) map[string]interface{} {
 	if len(params) < 3 {
-		return UnetworkRpcNil
+		return UNetworkRPCNil
 	}
 	var asset, address, value string
 	switch params[0].(type) {
 	case string:
 		asset = params[0].(string)
 	default:
-		return UnetworkRpcInvalidParameter
+		return UNetworkRPCInvalidParameter
 	}
 	switch params[1].(type) {
 	case string:
 		address = params[1].(string)
 	default:
-		return UnetworkRpcInvalidParameter
+		return UNetworkRPCInvalidParameter
 	}
 	switch params[2].(type) {
 	case string:
 		value = params[2].(string)
 	default:
-		return UnetworkRpcInvalidParameter
+		return UNetworkRPCInvalidParameter
 	}
 	if Wallet == nil {
-		return UnetworkRpc("error : wallet is not opened")
+		return UNetworkRPC("error : wallet is not opened")
 	}
 
 	batchOut := sdk.BatchOut{
@@ -712,27 +712,27 @@ func sendToAddress(params []interface{}) map[string]interface{} {
 	}
 	tmp, err := HexStringToBytesReverse(asset)
 	if err != nil {
-		return UnetworkRpc("error: invalid asset ID")
+		return UNetworkRPC("error: invalid asset ID")
 	}
 	var assetID Uint256
 	if err := assetID.Deserialize(bytes.NewReader(tmp)); err != nil {
-		return UnetworkRpc("error: invalid asset hash")
+		return UNetworkRPC("error: invalid asset hash")
 	}
 	txn, err := sdk.MakeTransferTransaction(Wallet, assetID, batchOut)
 	if err != nil {
-		return UnetworkRpc("error: " + err.Error())
+		return UNetworkRPC("error: " + err.Error())
 	}
 
 	if errCode := VerifyAndSendTx(txn); errCode != ErrNoError {
-		return UnetworkRpc("error: " + errCode.Error())
+		return UNetworkRPC("error: " + errCode.Error())
 	}
 	txHash := txn.Hash()
-	return UnetworkRpc(BytesToHexString(txHash.ToArrayReverse()))
+	return UNetworkRPC(BytesToHexString(txHash.ToArrayReverse()))
 }
 
 func lockAsset(params []interface{}) map[string]interface{} {
 	if len(params) < 3 {
-		return UnetworkRpcNil
+		return UNetworkRPCNil
 	}
 	var asset, value string
 	var height float64
@@ -740,67 +740,67 @@ func lockAsset(params []interface{}) map[string]interface{} {
 	case string:
 		asset = params[0].(string)
 	default:
-		return UnetworkRpcInvalidParameter
+		return UNetworkRPCInvalidParameter
 	}
 	switch params[1].(type) {
 	case string:
 		value = params[1].(string)
 	default:
-		return UnetworkRpcInvalidParameter
+		return UNetworkRPCInvalidParameter
 	}
 	switch params[2].(type) {
 	case float64:
 		height = params[2].(float64)
 	default:
-		return UnetworkRpcInvalidParameter
+		return UNetworkRPCInvalidParameter
 	}
 	if Wallet == nil {
-		return UnetworkRpc("error: invalid wallet instance")
+		return UNetworkRPC("error: invalid wallet instance")
 	}
 
 	accts := Wallet.GetAccounts()
 	if len(accts) > 1 {
-		return UnetworkRpc("error: does't support multi-addresses wallet locking asset")
+		return UNetworkRPC("error: does't support multi-addresses wallet locking asset")
 	}
 
 	tmp, err := HexStringToBytesReverse(asset)
 	if err != nil {
-		return UnetworkRpc("error: invalid asset ID")
+		return UNetworkRPC("error: invalid asset ID")
 	}
 	var assetID Uint256
 	if err := assetID.Deserialize(bytes.NewReader(tmp)); err != nil {
-		return UnetworkRpc("error: invalid asset hash")
+		return UNetworkRPC("error: invalid asset hash")
 	}
 
 	txn, err := sdk.MakeLockAssetTransaction(Wallet, assetID, value, uint32(height))
 	if err != nil {
-		return UnetworkRpc("error: " + err.Error())
+		return UNetworkRPC("error: " + err.Error())
 	}
 
 	txnHash := txn.Hash()
 	if errCode := VerifyAndSendTx(txn); errCode != ErrNoError {
-		return UnetworkRpc(errCode.Error())
+		return UNetworkRPC(errCode.Error())
 	}
-	return UnetworkRpc(BytesToHexString(txnHash.ToArrayReverse()))
+	return UNetworkRPC(BytesToHexString(txnHash.ToArrayReverse()))
 }
 
 func signMultisigTransaction(params []interface{}) map[string]interface{} {
 	if len(params) < 1 {
-		return UnetworkRpcNil
+		return UNetworkRPCNil
 	}
 	var signedrawtxn string
 	switch params[0].(type) {
 	case string:
 		signedrawtxn = params[0].(string)
 	default:
-		return UnetworkRpcInvalidParameter
+		return UNetworkRPCInvalidParameter
 	}
 
 	rawtxn, _ := HexStringToBytes(signedrawtxn)
 	var txn tx.Transaction
 	txn.Deserialize(bytes.NewReader(rawtxn))
 	if len(txn.Programs) <= 0 {
-		return UnetworkRpc("missing the first signature")
+		return UNetworkRPC("missing the first signature")
 	}
 
 	found := false
@@ -814,57 +814,57 @@ func signMultisigTransaction(params []interface{}) map[string]interface{} {
 		}
 	}
 	if !found {
-		return UnetworkRpc("error: no available account detected")
+		return UNetworkRPC("error: no available account detected")
 	}
 
 	_, needsig, err := txn.ParseTransactionSig()
 	if err != nil {
-		return UnetworkRpc("error: " + err.Error())
+		return UNetworkRPC("error: " + err.Error())
 	}
 	if needsig == 0 {
 		txnHash := txn.Hash()
 		if errCode := VerifyAndSendTx(&txn); errCode != ErrNoError {
-			return UnetworkRpc(errCode.Error())
+			return UNetworkRPC(errCode.Error())
 		}
-		return UnetworkRpc(BytesToHexString(txnHash.ToArrayReverse()))
+		return UNetworkRPC(BytesToHexString(txnHash.ToArrayReverse()))
 	} else {
 		var buffer bytes.Buffer
 		txn.Serialize(&buffer)
-		return UnetworkRpc(BytesToHexString(buffer.Bytes()))
+		return UNetworkRPC(BytesToHexString(buffer.Bytes()))
 	}
 }
 
 func createMultisigTransaction(params []interface{}) map[string]interface{} {
 	if len(params) < 4 {
-		return UnetworkRpcNil
+		return UNetworkRPCNil
 	}
 	var asset, from, address, value string
 	switch params[0].(type) {
 	case string:
 		asset = params[0].(string)
 	default:
-		return UnetworkRpcInvalidParameter
+		return UNetworkRPCInvalidParameter
 	}
 	switch params[1].(type) {
 	case string:
 		from = params[1].(string)
 	default:
-		return UnetworkRpcInvalidParameter
+		return UNetworkRPCInvalidParameter
 	}
 	switch params[2].(type) {
 	case string:
 		address = params[2].(string)
 	default:
-		return UnetworkRpcInvalidParameter
+		return UNetworkRPCInvalidParameter
 	}
 	switch params[3].(type) {
 	case string:
 		value = params[3].(string)
 	default:
-		return UnetworkRpcInvalidParameter
+		return UNetworkRPCInvalidParameter
 	}
 	if Wallet == nil {
-		return UnetworkRpc("error : wallet is not opened")
+		return UNetworkRPC("error : wallet is not opened")
 	}
 
 	batchOut := sdk.BatchOut{
@@ -873,37 +873,37 @@ func createMultisigTransaction(params []interface{}) map[string]interface{} {
 	}
 	tmp, err := HexStringToBytesReverse(asset)
 	if err != nil {
-		return UnetworkRpc("error: invalid asset ID")
+		return UNetworkRPC("error: invalid asset ID")
 	}
 	var assetID Uint256
 	if err := assetID.Deserialize(bytes.NewReader(tmp)); err != nil {
-		return UnetworkRpc("error: invalid asset hash")
+		return UNetworkRPC("error: invalid asset hash")
 	}
 	txn, err := sdk.MakeMultisigTransferTransaction(Wallet, assetID, from, batchOut)
 	if err != nil {
-		return UnetworkRpc("error: " + err.Error())
+		return UNetworkRPC("error: " + err.Error())
 	}
 
 	_, needsig, err := txn.ParseTransactionSig()
 	if err != nil {
-		return UnetworkRpc("error: " + err.Error())
+		return UNetworkRPC("error: " + err.Error())
 	}
 	if needsig == 0 {
 		txnHash := txn.Hash()
 		if errCode := VerifyAndSendTx(txn); errCode != ErrNoError {
-			return UnetworkRpc(errCode.Error())
+			return UNetworkRPC(errCode.Error())
 		}
-		return UnetworkRpc(BytesToHexString(txnHash.ToArrayReverse()))
+		return UNetworkRPC(BytesToHexString(txnHash.ToArrayReverse()))
 	} else {
 		var buffer bytes.Buffer
 		txn.Serialize(&buffer)
-		return UnetworkRpc(BytesToHexString(buffer.Bytes()))
+		return UNetworkRPC(BytesToHexString(buffer.Bytes()))
 	}
 }
 
 func getBalance(params []interface{}) map[string]interface{} {
 	if Wallet == nil {
-		return UnetworkRpc("open wallet first")
+		return UNetworkRPC("open wallet first")
 	}
 	type AssetInfo struct {
 		AssetID string
@@ -935,89 +935,89 @@ func getBalance(params []interface{}) map[string]interface{} {
 		balances[address] = assetList
 	}
 
-	return UnetworkRpc(balances)
+	return UNetworkRPC(balances)
 }
 
 func registerUser(params []interface{}) map[string]interface{} {
 	if len(params) < 2 {
-		return UnetworkRpcNil
+		return UNetworkRPCNil
 	}
 	var userName, userProgramHash string
 	switch params[0].(type) {
 	case string:
 		userName = params[0].(string)
 	default:
-		return UnetworkRpcInvalidParameter
+		return UNetworkRPCInvalidParameter
 	}
 	switch params[1].(type) {
 	case string:
 		userProgramHash = params[1].(string)
 	default:
-		return UnetworkRpcInvalidParameter
+		return UNetworkRPCInvalidParameter
 	}
 	tmp, err := HexStringToBytesReverse(userProgramHash)
 	if err != nil {
-		return UnetworkRpcInvalidParameter
+		return UNetworkRPCInvalidParameter
 	}
 	programHash, err := Uint160ParseFromBytes(tmp)
 	if err != nil {
-		return UnetworkRpcInvalidParameter
+		return UNetworkRPCInvalidParameter
 	}
 	txn, err := sdk.MakeRegisterUserTransaction(userName, programHash)
 	if err != nil {
-		return UnetworkRpcInternalError
+		return UNetworkRPCInternalError
 	}
 
 	hash := txn.Hash()
 	if errCode := VerifyAndSendTx(txn); errCode != ErrNoError {
-		return UnetworkRpc(errCode.Error())
+		return UNetworkRPC(errCode.Error())
 	}
 
-	return UnetworkRpc(BytesToHexString(hash.ToArrayReverse()))
+	return UNetworkRPC(BytesToHexString(hash.ToArrayReverse()))
 }
 
 func postArticle(params []interface{}) map[string]interface{} {
 	if len(params) < 2 {
-		return UnetworkRpcNil
+		return UNetworkRPCNil
 	}
 	var articleHash, author string
 	switch params[0].(type) {
 	case string:
 		articleHash = params[0].(string)
 	default:
-		return UnetworkRpcInvalidParameter
+		return UNetworkRPCInvalidParameter
 	}
 	switch params[1].(type) {
 	case string:
 		author = params[1].(string)
 	default:
-		return UnetworkRpcInvalidParameter
+		return UNetworkRPCInvalidParameter
 	}
 
 	tmpHash, err := HexStringToBytes(articleHash)
 	if err != nil {
-		return UnetworkRpcInvalidParameter
+		return UNetworkRPCInvalidParameter
 	}
 	aHash, err := Uint256ParseFromBytes(tmpHash)
 	if err != nil {
-		return UnetworkRpcInvalidParameter
+		return UNetworkRPCInvalidParameter
 	}
 	txn, err := sdk.MakePostArticleTransaction(Wallet, aHash, author)
 	if err != nil {
-		return UnetworkRpcInternalError
+		return UNetworkRPCInternalError
 	}
 
 	hash := txn.Hash()
 	if errCode := VerifyAndSendTx(txn); errCode != ErrNoError {
-		return UnetworkRpc(errCode.Error())
+		return UNetworkRPC(errCode.Error())
 	}
 
-	return UnetworkRpc(BytesToHexString(hash.ToArrayReverse()))
+	return UNetworkRPC(BytesToHexString(hash.ToArrayReverse()))
 }
 
 func replyArticle(params []interface{}) map[string]interface{} {
 	if len(params) < 3 {
-		return UnetworkRpcNil
+		return UNetworkRPCNil
 	}
 	var postTxnHash, contentHash, replier string
 	var err error
@@ -1025,55 +1025,55 @@ func replyArticle(params []interface{}) map[string]interface{} {
 	case string:
 		postTxnHash = params[0].(string)
 	default:
-		return UnetworkRpcInvalidParameter
+		return UNetworkRPCInvalidParameter
 	}
 	switch params[1].(type) {
 	case string:
 		contentHash = params[1].(string)
 	default:
-		return UnetworkRpcInvalidParameter
+		return UNetworkRPCInvalidParameter
 	}
 	switch params[2].(type) {
 	case string:
 		replier = params[2].(string)
 	default:
-		return UnetworkRpcInvalidParameter
+		return UNetworkRPCInvalidParameter
 	}
 
 	tmpHash, err := HexStringToBytesReverse(postTxnHash)
 	if err != nil {
-		return UnetworkRpcInvalidParameter
+		return UNetworkRPCInvalidParameter
 	}
 	pHash, err := Uint256ParseFromBytes(tmpHash)
 	if err != nil {
-		return UnetworkRpcInvalidParameter
+		return UNetworkRPCInvalidParameter
 	}
 
 	tmpHash, err = HexStringToBytes(contentHash)
 	if err != nil {
-		return UnetworkRpcInvalidParameter
+		return UNetworkRPCInvalidParameter
 	}
 	cHash, err := Uint256ParseFromBytes(tmpHash)
 	if err != nil {
-		return UnetworkRpcInvalidParameter
+		return UNetworkRPCInvalidParameter
 	}
 
 	txn, err := sdk.MakeReplyArticleTransaction(Wallet, pHash, cHash, replier)
 	if err != nil {
-		return UnetworkRpcInternalError
+		return UNetworkRPCInternalError
 	}
 
 	hash := txn.Hash()
 	if errCode := VerifyAndSendTx(txn); errCode != ErrNoError {
-		return UnetworkRpc(errCode.Error())
+		return UNetworkRPC(errCode.Error())
 	}
 
-	return UnetworkRpc(BytesToHexString(hash.ToArrayReverse()))
+	return UNetworkRPC(BytesToHexString(hash.ToArrayReverse()))
 }
 
 func likeArticle(params []interface{}) map[string]interface{} {
 	if len(params) < 3 {
-		return UnetworkRpcNil
+		return UNetworkRPCNil
 	}
 	var postTxnHash, liker string
 	var likeType forum.LikeType
@@ -1081,103 +1081,103 @@ func likeArticle(params []interface{}) map[string]interface{} {
 	case string:
 		postTxnHash = params[0].(string)
 	default:
-		return UnetworkRpcInvalidParameter
+		return UNetworkRPCInvalidParameter
 	}
 	switch params[1].(type) {
 	case string:
 		liker = params[1].(string)
 	default:
-		return UnetworkRpcInvalidParameter
+		return UNetworkRPCInvalidParameter
 	}
 	switch params[2].(type) {
 	case string:
 		v, err := strconv.ParseInt(params[2].(string), 10, 8)
 		if err != nil {
-			return UnetworkRpcInvalidParameter
+			return UNetworkRPCInvalidParameter
 		}
 		likeType = forum.LikeType(v)
 	default:
-		return UnetworkRpcInvalidParameter
+		return UNetworkRPCInvalidParameter
 	}
 
 	tmpHash, err := HexStringToBytesReverse(postTxnHash)
 	if err != nil {
-		return UnetworkRpcInvalidParameter
+		return UNetworkRPCInvalidParameter
 	}
 	aHash, err := Uint256ParseFromBytes(tmpHash)
 	if err != nil {
-		return UnetworkRpcInvalidParameter
+		return UNetworkRPCInvalidParameter
 	}
 	txn, err := sdk.MakeLikeArticleTransaction(Wallet, aHash, liker, likeType)
 	if err != nil {
-		return UnetworkRpcInternalError
+		return UNetworkRPCInternalError
 	}
 
 	hash := txn.Hash()
 	if errCode := VerifyAndSendTx(txn); errCode != ErrNoError {
-		return UnetworkRpc(errCode.Error())
+		return UNetworkRPC(errCode.Error())
 	}
 
-	return UnetworkRpc(BytesToHexString(hash.ToArrayReverse()))
+	return UNetworkRPC(BytesToHexString(hash.ToArrayReverse()))
 }
 
 func withdrawal(params []interface{}) map[string]interface{} {
 	if len(params) < 3 {
-		return UnetworkRpcNil
+		return UNetworkRPCNil
 	}
 	var payee, recipient, asset, amount string
 	switch params[0].(type) {
 	case string:
 		payee = params[0].(string)
 	default:
-		return UnetworkRpcInvalidParameter
+		return UNetworkRPCInvalidParameter
 	}
 	switch params[1].(type) {
 	case string:
 		recipient = params[1].(string)
 	default:
-		return UnetworkRpcInvalidParameter
+		return UNetworkRPCInvalidParameter
 	}
 	switch params[2].(type) {
 	case string:
 		asset = params[2].(string)
 	default:
-		return UnetworkRpcInvalidParameter
+		return UNetworkRPCInvalidParameter
 	}
 	switch params[3].(type) {
 	case string:
 		amount = params[3].(string)
 	default:
-		return UnetworkRpcInvalidParameter
+		return UNetworkRPCInvalidParameter
 	}
 
 	tmpHash, err := HexStringToBytesReverse(recipient)
 	if err != nil {
-		return UnetworkRpcInvalidParameter
+		return UNetworkRPCInvalidParameter
 	}
 	aHash, err := Uint160ParseFromBytes(tmpHash)
 	if err != nil {
-		return UnetworkRpcInvalidParameter
+		return UNetworkRPCInvalidParameter
 	}
 
 	tmpHash, err = HexStringToBytesReverse(asset)
 	if err != nil {
-		return UnetworkRpcInvalidParameter
+		return UNetworkRPCInvalidParameter
 	}
 	bHash, err := Uint256ParseFromBytes(tmpHash)
 	if err != nil {
-		return UnetworkRpcInvalidParameter
+		return UNetworkRPCInvalidParameter
 	}
 
 	txn, err := sdk.MakeWithdrawalTransaction(Wallet, payee, aHash, bHash, amount)
 	if err != nil {
-		return UnetworkRpcInternalError
+		return UNetworkRPCInternalError
 	}
 
 	hash := txn.Hash()
 	if errCode := VerifyAndSendTx(txn); errCode != ErrNoError {
-		return UnetworkRpc(errCode.Error())
+		return UNetworkRPC(errCode.Error())
 	}
 
-	return UnetworkRpc(BytesToHexString(hash.ToArrayReverse()))
+	return UNetworkRPC(BytesToHexString(hash.ToArrayReverse()))
 }

--- a/net/httpjsonrpc/rpcResult.go
+++ b/net/httpjsonrpc/rpcResult.go
@@ -1,25 +1,25 @@
 package httpjsonrpc
 
 var (
-	UnetworkRpcInvalidHash        = responsePacking("invalid hash")
-	UnetworkRpcInvalidBlock       = responsePacking("invalid block")
-	UnetworkRpcInvalidTransaction = responsePacking("invalid transaction")
-	UnetworkRpcInvalidParameter   = responsePacking("invalid parameter")
+	UNetworkRPCInvalidHash        = responsePacking("invalid hash")
+	UNetworkRPCInvalidBlock       = responsePacking("invalid block")
+	UNetworkRPCInvalidTransaction = responsePacking("invalid transaction")
+	UNetworkRPCInvalidParameter   = responsePacking("invalid parameter")
 
-	UnetworkRpcUnknownBlock       = responsePacking("unknown block")
-	UnetworkRpcUnknownTransaction = responsePacking("unknown transaction")
+	UNetworkRPCUnknownBlock       = responsePacking("unknown block")
+	UNetworkRPCUnknownTransaction = responsePacking("unknown transaction")
 
-	UnetworkRpcNil           = responsePacking(nil)
-	UnetworkRpcUnsupported   = responsePacking("Unsupported")
-	UnetworkRpcInternalError = responsePacking("internal error")
-	UnetworkRpcIOError       = responsePacking("internal IO error")
-	UnetworkRpcAPIError      = responsePacking("internal API error")
-	UnetworkRpcSuccess       = responsePacking(true)
-	UnetworkRpcFailed        = responsePacking(false)
+	UNetworkRPCNil           = responsePacking(nil)
+	UNetworkRPCUnsupported   = responsePacking("Unsupported")
+	UNetworkRPCInternalError = responsePacking("internal error")
+	UNetworkRPCIOError       = responsePacking("internal IO error")
+	UNetworkRPCAPIError      = responsePacking("internal API error")
+	UNetworkRPCSuccess       = responsePacking(true)
+	UNetworkRPCFailed        = responsePacking(false)
 
 	// error code for wallet
-	UnetworkRpcWalletAlreadyExists = responsePacking("wallet already exist")
-	UnetworkRpcWalletNotExists     = responsePacking("wallet doesn't exist")
+	UNetworkRPCWalletAlreadyExists = responsePacking("wallet already exist")
+	UNetworkRPCWalletNotExists     = responsePacking("wallet doesn't exist")
 
-	UnetworkRpc = responsePacking
+	UNetworkRPC = responsePacking
 )

--- a/net/httpnodeinfo/server.go
+++ b/net/httpnodeinfo/server.go
@@ -29,7 +29,7 @@ const (
 	serviceNode = "Service Node"
 )
 
-var node Noder
+var node UNode
 
 var templates = template.Must(template.New("info").Parse(page))
 
@@ -50,7 +50,7 @@ func initPageInfo(blockHeight uint32, curNodeType string, ngbrCnt int, ngbrsInfo
 }
 
 func viewHandler(w http.ResponseWriter, r *http.Request) {
-	var ngbrNodersInfo []NgbNodeInfo
+	var ngbrUNodesInfo []NgbNodeInfo
 	var ngbId string
 	var ngbAddr string
 	var ngbType string
@@ -68,30 +68,30 @@ func viewHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	ngbrNoders := node.GetNeighborNoder()
-	ngbrsLen := len(ngbrNoders)
+	ngbrUNodes := node.GetNeighborUNode()
+	ngbrsLen := len(ngbrUNodes)
 	for i := 0; i < ngbrsLen; i++ {
 		ngbType = serviceNode
 		for j := 0; j < bookKeeperLen; j++ {
-			if ngbrNoders[i].GetPubKey().X.Cmp(bookKeepers[j].X) == 0 {
+			if ngbrUNodes[i].GetPubKey().X.Cmp(bookKeepers[j].X) == 0 {
 				ngbType = verifyNode
 				break
 			}
 		}
 
-		ngbAddr = ngbrNoders[i].GetAddr()
-		ngbInfoPort = ngbrNoders[i].GetHttpInfoPort()
-		ngbInfoState = ngbrNoders[i].GetHttpInfoState()
+		ngbAddr = ngbrUNodes[i].GetAddr()
+		ngbInfoPort = ngbrUNodes[i].GetHttpInfoPort()
+		ngbInfoState = ngbrUNodes[i].GetHttpInfoState()
 		ngbHttpInfoAddr = ngbAddr + ":" + strconv.Itoa(ngbInfoPort)
-		ngbId = fmt.Sprintf("0x%x", ngbrNoders[i].GetID())
+		ngbId = fmt.Sprintf("0x%x", ngbrUNodes[i].GetID())
 
 		ngbrInfo := newNgbNodeInfo(ngbId, ngbType, ngbAddr, ngbHttpInfoAddr, ngbInfoPort, ngbInfoState)
-		ngbrNodersInfo = append(ngbrNodersInfo, *ngbrInfo)
+		ngbrUNodesInfo = append(ngbrUNodesInfo, *ngbrInfo)
 	}
-	sort.Sort(NgbNodeInfoSlice(ngbrNodersInfo))
+	sort.Sort(NgbNodeInfoSlice(ngbrUNodesInfo))
 
 	blockHeight := ledger.DefaultLedger.Blockchain.BlockHeight
-	pageInfo, err := initPageInfo(blockHeight, curNodeType, ngbrsLen, ngbrNodersInfo)
+	pageInfo, err := initPageInfo(blockHeight, curNodeType, ngbrsLen, ngbrUNodesInfo)
 	if err != nil {
 		http.Redirect(w, r, "/info", http.StatusFound)
 		return
@@ -103,7 +103,7 @@ func viewHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func StartServer(n Noder) {
+func StartServer(n UNode) {
 	node = n
 	port := int(config.Parameters.HttpInfoPort)
 	http.HandleFunc("/info", viewHandler)

--- a/net/httprestful/common/common.go
+++ b/net/httprestful/common/common.go
@@ -17,7 +17,7 @@ import (
 
 )
 
-var node Noder
+var node UNode
 
 const TlsPort int = 443
 
@@ -26,7 +26,7 @@ type ApiServer interface {
 	Stop()
 }
 
-func SetNode(n Noder) {
+func SetNode(n UNode) {
 	node = n
 }
 

--- a/net/httprestful/server.go
+++ b/net/httprestful/server.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 )
 
-func StartServer(n Noder) {
+func StartServer(n UNode) {
 	common.SetNode(n)
 	ledger.DefaultLedger.Blockchain.BCEvents.Subscribe(events.EventBlockPersistCompleted, SendBlock2NoticeServer)
 	func() {

--- a/net/httpwebsocket/server.go
+++ b/net/httpwebsocket/server.go
@@ -21,7 +21,7 @@ var (
 	pushBlockTxsFlag bool = false
 )
 
-func StartServer(n Noder) {
+func StartServer(n UNode) {
 	common.SetNode(n)
 	ledger.DefaultLedger.Blockchain.BCEvents.Subscribe(events.EventBlockPersistCompleted, SendBlock2WSclient)
 	ledger.DefaultLedger.Blockchain.BCEvents.Subscribe(events.EventChatMessage, SendChatMessage2WSclient)

--- a/net/message/address.go
+++ b/net/message/address.go
@@ -87,7 +87,7 @@ func (msg addrReq) Verify(buf []byte) error {
 	return err
 }
 
-func (msg addrReq) Handle(node Noder) error {
+func (msg addrReq) Handle(node UNode) error {
 	log.Debug()
 	// lock
 	var addrstr []NodeAddr
@@ -160,7 +160,7 @@ func (msg addr) Verify(buf []byte) error {
 	return err
 }
 
-func (msg addr) Handle(node Noder) error {
+func (msg addr) Handle(node UNode) error {
 	log.Debug()
 	for _, v := range msg.nodeAddrs {
 		var ip net.IP

--- a/net/message/block.go
+++ b/net/message/block.go
@@ -24,7 +24,7 @@ type block struct {
 	//event *events.Event
 }
 
-func (msg block) Handle(node Noder) error {
+func (msg block) Handle(node UNode) error {
 	log.Debug("RX block message")
 	hash := msg.blk.Hash()
 	isSync := false
@@ -41,7 +41,7 @@ func (msg block) Handle(node Noder) error {
 		log.Warn("clean transaction pool error")
 		return err
 	}
-	for _, n := range node.LocalNode().GetNeighborNoder() {
+	for _, n := range node.LocalNode().GetNeighborUNode() {
 		if n.ExistFlightHeight(msg.blk.Blockdata.Height) {
 			//sync block
 			n.RemoveFlightHeight(msg.blk.Blockdata.Height)
@@ -56,7 +56,7 @@ func (msg block) Handle(node Noder) error {
 	return nil
 }
 
-func (msg dataReq) Handle(node Noder) error {
+func (msg dataReq) Handle(node UNode) error {
 	log.Debug()
 	reqtype := common.InventoryType(msg.dataType)
 	hash := msg.hash
@@ -132,7 +132,7 @@ func NewBlock(bk *ledger.Block) ([]byte, error) {
 	return m, nil
 }
 
-func ReqBlkData(node Noder, hash common.Uint256) error {
+func ReqBlkData(node UNode, hash common.Uint256) error {
 	var msg dataReq
 	msg.dataType = common.BLOCK
 	msg.hash = hash

--- a/net/message/blockHdr.go
+++ b/net/message/blockHdr.go
@@ -147,7 +147,7 @@ blkHdrErr:
 	return err
 }
 
-func (msg headersReq) Handle(node Noder) error {
+func (msg headersReq) Handle(node UNode) error {
 	log.Debug()
 	// lock
 	var startHash [HASHLEN]byte
@@ -167,7 +167,7 @@ func (msg headersReq) Handle(node Noder) error {
 	return nil
 }
 
-func SendMsgSyncHeaders(node Noder) {
+func SendMsgSyncHeaders(node UNode) {
 	buf, err := NewHeadersReq()
 	if err != nil {
 		log.Error("failed build a new headersReq")
@@ -176,7 +176,7 @@ func SendMsgSyncHeaders(node Noder) {
 	}
 }
 
-func (msg blkHeader) Handle(node Noder) error {
+func (msg blkHeader) Handle(node UNode) error {
 	log.Debug()
 	err := ledger.DefaultLedger.Store.AddHeaders(msg.blkHdr, ledger.DefaultLedger)
 	if err != nil {

--- a/net/message/chat.go
+++ b/net/message/chat.go
@@ -62,7 +62,7 @@ func (msg chat) Verify(buf []byte) error {
 	return msg.msgHdr.Verify(buf)
 }
 
-func (msg chat) Handle(node Noder) error {
+func (msg chat) Handle(node UNode) error {
 	payload := &msg.ChatPayload
 	if !node.LocalNode().ExistedID(payload.Hash()) {
 		node.LocalNode().Relay(node, payload)

--- a/net/message/consensus.go
+++ b/net/message/consensus.go
@@ -107,7 +107,7 @@ func (cp *ConsensusPayload) GetMessage() []byte {
 	//return []byte{}
 }
 
-func (msg consensus) Handle(node Noder) error {
+func (msg consensus) Handle(node UNode) error {
 	log.Debug()
 	cp := &msg.cons
 	if !node.LocalNode().ExistedID(cp.Hash()) {
@@ -118,7 +118,7 @@ func (msg consensus) Handle(node Noder) error {
 	return nil
 }
 
-func reqConsensusData(node Noder, hash common.Uint256) error {
+func reqConsensusData(node UNode, hash common.Uint256) error {
 	var msg dataReq
 	msg.dataType = common.CONSENSUS
 	// TODO handle the hash array case

--- a/net/message/inventory.go
+++ b/net/message/inventory.go
@@ -34,7 +34,7 @@ type Inv struct {
 	P   InvPayload
 }
 
-func NewBlocksReq(n Noder) ([]byte, error) {
+func NewBlocksReq(n UNode) ([]byte, error) {
 	var h blocksReq
 	log.Debug("request block hash")
 	// Fixme correct with the exactly request length
@@ -66,7 +66,7 @@ func (msg blocksReq) Verify(buf []byte) error {
 	return err
 }
 
-func (msg blocksReq) Handle(node Noder) error {
+func (msg blocksReq) Handle(node UNode) error {
 	log.Debug()
 	log.Debug("handle blocks request")
 	var starthash Uint256
@@ -109,7 +109,7 @@ func (msg Inv) Verify(buf []byte) error {
 	return err
 }
 
-func (msg Inv) Handle(node Noder) error {
+func (msg Inv) Handle(node UNode) error {
 	log.Debug()
 	var id Uint256
 	str := hex.EncodeToString(msg.P.Blk)

--- a/net/message/message.go
+++ b/net/message/message.go
@@ -15,7 +15,7 @@ type Messager interface {
 	Verify([]byte) error
 	Serialization() ([]byte, error)
 	Deserialization([]byte) error
-	Handle(Noder) error
+	Handle(UNode) error
 }
 
 // The network communication message header
@@ -178,7 +178,7 @@ func MsgType(buf []byte) (string, error) {
 }
 
 // TODO combine all of message alloc in one function via interface
-func NewMsg(t string, n Noder) ([]byte, error) {
+func NewMsg(t string, n UNode) ([]byte, error) {
 	switch t {
 	case "version":
 		return NewVersion(n)
@@ -195,7 +195,7 @@ func NewMsg(t string, n Noder) ([]byte, error) {
 }
 
 // FIXME the length exceed int32 case?
-func HandleNodeMsg(node Noder, buf []byte, len int) error {
+func HandleNodeMsg(node UNode, buf []byte, len int) error {
 	if len < MSGHDRLEN {
 		log.Warn("Unexpected size of received message")
 		return errors.New("Unexpected size of received message")
@@ -315,7 +315,7 @@ func (hdr msgHdr) Serialization() ([]byte, error) {
 	return buf.Bytes(), err
 }
 
-func (hdr msgHdr) Handle(n Noder) error {
+func (hdr msgHdr) Handle(n UNode) error {
 	log.Debug()
 	// TBD
 	return nil

--- a/net/message/notfound.go
+++ b/net/message/notfound.go
@@ -82,7 +82,7 @@ func (msg *notFound) Deserialization(p []byte) error {
 	return err
 }
 
-func (msg notFound) Handle(node Noder) error {
+func (msg notFound) Handle(node UNode) error {
 	log.Debug("RX notfound message, hash is ", msg.hash)
 	return nil
 }

--- a/net/message/ping.go
+++ b/net/message/ping.go
@@ -49,7 +49,7 @@ func (msg ping) Verify(buf []byte) error {
 	return err
 }
 
-func (msg ping) Handle(node Noder) error {
+func (msg ping) Handle(node UNode) error {
 	node.SetHeight(msg.height)
 	buf, err := NewPongMsg()
 	if err != nil {

--- a/net/message/pong.go
+++ b/net/message/pong.go
@@ -49,7 +49,7 @@ func (msg pong) Verify(buf []byte) error {
 	return err
 }
 
-func (msg pong) Handle(node Noder) error {
+func (msg pong) Handle(node UNode) error {
 	node.SetHeight(msg.height)
 	return nil
 }

--- a/net/message/transaction.go
+++ b/net/message/transaction.go
@@ -28,7 +28,7 @@ type trn struct {
 	//hash common.Uint256
 }
 
-func (msg trn) Handle(node Noder) error {
+func (msg trn) Handle(node UNode) error {
 	log.Debug()
 	log.Debug("RX Transaction message")
 	tx := &msg.txn
@@ -46,7 +46,7 @@ func (msg trn) Handle(node Noder) error {
 	return nil
 }
 
-func reqTxnData(node Noder, hash common.Uint256) error {
+func reqTxnData(node UNode, hash common.Uint256) error {
 	var msg dataReq
 	msg.dataType = common.TRANSACTION
 	// TODO handle the hash array case
@@ -163,7 +163,7 @@ type txnPool struct {
 	//TBD
 }
 
-func ReqTxnPool(node Noder) error {
+func ReqTxnPool(node UNode) error {
 	msg := AllocMsg("txnpool", 0)
 	buf, _ := msg.Serialization()
 	go node.Tx(buf)

--- a/net/message/verack.go
+++ b/net/message/verack.go
@@ -49,7 +49,7 @@ func NewVerack() ([]byte, error) {
  *
  */
 // TODO The process should be adjusted based on above table
-func (msg verACK) Handle(node Noder) error {
+func (msg verACK) Handle(node UNode) error {
 	log.Debug()
 
 	s := node.GetState()

--- a/net/message/version.go
+++ b/net/message/version.go
@@ -37,11 +37,11 @@ type version struct {
 	pk *crypto.PubKey
 }
 
-func (msg *version) init(n Noder) {
+func (msg *version) init(n UNode) {
 	// Do the init
 }
 
-func NewVersion(n Noder) ([]byte, error) {
+func NewVersion(n UNode) ([]byte, error) {
 	log.Debug()
 	var msg version
 
@@ -159,7 +159,7 @@ func (msg *version) Deserialization(p []byte) error {
  * |          |   No Action     |           | No Action  | No Action       |
  * |------------------------------------------------------------------------
  */
-func (msg version) Handle(node Noder) error {
+func (msg version) Handle(node UNode) error {
 	log.Debug()
 	localNode := node.LocalNode()
 

--- a/net/net.go
+++ b/net/net.go
@@ -17,12 +17,12 @@ type Neter interface {
 	GetEvent(eventName string) *events.Event
 	GetBookKeepersAddrs() ([]*crypto.PubKey, uint64)
 	CleanSubmittedTransactions(block *ledger.Block) error
-	GetNeighborNoder() []protocol.Noder
+	GetNeighborUNode() []protocol.UNode
 	Tx(buf []byte)
 	AppendTxnPool(*transaction.Transaction, bool) ErrCode
 }
 
-func StartProtocol(pubKey *crypto.PubKey) protocol.Noder {
+func StartProtocol(pubKey *crypto.PubKey) protocol.UNode {
 	net := node.InitNode(pubKey)
 	net.ConnectSeeds()
 

--- a/net/node/infoUpdate.go
+++ b/net/node/infoUpdate.go
@@ -12,7 +12,7 @@ import (
 	"time"
 )
 
-func keepAlive(from *Noder, dst *Noder) {
+func keepAlive(from *UNode, dst *UNode) {
 	// Need move to node function or keep here?
 }
 
@@ -20,11 +20,11 @@ func (node *node) GetBlkHdrs() {
 	if node.local.GetNbrNodeCnt() < MINCONNCNT {
 		return
 	}
-	noders := node.local.GetNeighborNoder()
+	noders := node.local.GetNeighborUNode()
 	if len(noders) == 0 {
 		return
 	}
-	nodelist := []Noder{}
+	nodelist := []UNode{}
 	for _, v := range noders {
 		if uint64(ledger.DefaultLedger.Store.GetHeaderHeight()) < v.GetHeight() {
 			nodelist = append(nodelist, v)
@@ -49,7 +49,7 @@ func (node *node) SyncBlk() {
 	var dValue int32
 	var reqCnt uint32
 	var i uint32
-	noders := node.local.GetNeighborNoder()
+	noders := node.local.GetNeighborUNode()
 
 	for _, n := range noders {
 		if uint32(n.GetHeight()) <= currentBlkHeight {
@@ -82,7 +82,7 @@ func (node *node) SyncBlk() {
 }
 
 func (node *node) SendPingToNbr() {
-	noders := node.local.GetNeighborNoder()
+	noders := node.local.GetNeighborUNode()
 	for _, n := range noders {
 		if n.GetState() == ESTABLISH {
 			buf, err := NewPingMsg()
@@ -96,7 +96,7 @@ func (node *node) SendPingToNbr() {
 }
 
 func (node *node) HeartBeatMonitor() {
-	noders := node.local.GetNeighborNoder()
+	noders := node.local.GetNeighborUNode()
 	for _, n := range noders {
 		if n.GetState() == ESTABLISH {
 			t := n.GetLastRXTime()
@@ -119,7 +119,7 @@ func (node *node) ConnectSeeds() {
 		seedNodes := config.Parameters.SeedList
 		for _, nodeAddr := range seedNodes {
 			found := false
-			var n Noder
+			var n UNode
 			var ip net.IP
 			node.nbrNodes.Lock()
 			for _, tn := range node.nbrNodes.List {

--- a/net/node/node.go
+++ b/net/node/node.go
@@ -149,7 +149,7 @@ func NewNode() *node {
 	return &n
 }
 
-func InitNode(pubKey *crypto.PubKey) Noder {
+func InitNode(pubKey *crypto.PubKey) UNode {
 	n := NewNode()
 	n.version = PROTOCOLVERSION
 	switch Parameters.NodeType {
@@ -286,7 +286,7 @@ func (node *node) CompareAndSetState(old, new uint32) bool {
 	return atomic.CompareAndSwapUint32(&(node.state), old, new)
 }
 
-func (node *node) LocalNode() Noder {
+func (node *node) LocalNode() UNode {
 	return node.local
 }
 
@@ -514,7 +514,7 @@ func (node *node) RemoveFromRetryList(addr string) {
 
 }
 
-func (node *node) Relay(frmnode Noder, message interface{}) error {
+func (node *node) Relay(frmnode UNode, message interface{}) error {
 	log.Debug()
 	var buffer []byte
 	var err error

--- a/net/node/nodeMap.go
+++ b/net/node/nodeMap.go
@@ -28,7 +28,7 @@ func (nm *nbrNodes) NodeExisted(uid uint64) bool {
 	return ok
 }
 
-func (nm *nbrNodes) AddNbrNode(n Noder) {
+func (nm *nbrNodes) AddNbrNode(n UNode) {
 	nm.Lock()
 	defer nm.Unlock()
 
@@ -44,7 +44,7 @@ func (nm *nbrNodes) AddNbrNode(n Noder) {
 	}
 }
 
-func (nm *nbrNodes) DelNbrNode(id uint64) (Noder, bool) {
+func (nm *nbrNodes) DelNbrNode(id uint64) (UNode, bool) {
 	nm.Lock()
 	defer nm.Unlock()
 
@@ -129,11 +129,11 @@ func (node *node) GetNeighborHeights() ([]uint64, uint64) {
 	return heights, i
 }
 
-func (node *node) GetNeighborNoder() []Noder {
+func (node *node) GetNeighborUNode() []UNode {
 	node.nbrNodes.RLock()
 	defer node.nbrNodes.RUnlock()
 
-	nodes := []Noder{}
+	nodes := []UNode{}
 	for _, n := range node.nbrNodes.List {
 		if n.GetState() == ESTABLISH {
 			node := n

--- a/net/protocol/protocol.go
+++ b/net/protocol/protocol.go
@@ -77,7 +77,7 @@ const (
 
 var ReceiveDuplicateBlockCnt uint64 //an index to detecting networking status
 
-type Noder interface {
+type UNode interface {
 	Version() uint32
 	GetID() uint64
 	Services() uint64
@@ -93,9 +93,9 @@ type Noder interface {
 	GetPubKey() *crypto.PubKey
 	CompareAndSetState(old, new uint32) bool
 	UpdateRXTime(t time.Time)
-	LocalNode() Noder
-	DelNbrNode(id uint64) (Noder, bool)
-	AddNbrNode(Noder)
+	LocalNode() UNode
+	DelNbrNode(id uint64) (UNode, bool)
+	AddNbrNode(UNode)
 	CloseConn()
 	GetHeight() uint64
 	GetConnectionCnt() uint
@@ -126,7 +126,7 @@ type Noder interface {
 	SyncNodeHeight()
 	CleanSubmittedTransactions(block *ledger.Block) error
 
-	GetNeighborNoder() []Noder
+	GetNeighborUNode() []UNode
 	GetNbrNodeCnt() uint32
 	StoreFlightHeight(height uint32)
 	GetFlightHeightCnt() int
@@ -142,7 +142,7 @@ type Noder interface {
 	RemoveAddrInConnectingList(addr string)
 	AddInRetryList(addr string)
 	RemoveFromRetryList(addr string)
-	Relay(Noder, interface{}) error
+	Relay(UNode, interface{}) error
 	ExistHash(hash common.Uint256) bool
 	CacheHash(hash common.Uint256)
 	ExistFlightHeight(height uint32) bool


### PR DESCRIPTION
1. Changed interface name from Noder to UNode to avoid confusion
2. Renaming variables with golang convention. 
@doraemon0 @yilugit 
Will merge after one approve. 